### PR TITLE
Release v0.1.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,0 @@
-packages: .
-
-source-repository-package
-    type: git
-    location: https://github.com/serras/avro.git
-    tag: c684139b773c296079a2941fb30ee43a52b66204

--- a/language-avro.cabal
+++ b/language-avro.cabal
@@ -17,7 +17,7 @@ library
   exposed-modules:     Language.Avro.Types,
                        Language.Avro.Parser
   build-depends:       base >=4.12 && <5
-                     , avro
+                     , avro >=0.4.7
                      , containers
                      , directory
                      , filepath
@@ -39,7 +39,7 @@ test-suite avro-parser-haskell-test
       -with-rtsopts=-N
   build-depends:
       base >=4.12 && <5
-    , avro
+    , avro >=0.4.7
     , language-avro
     , megaparsec
     , text

--- a/src/Language/Avro/Types.hs
+++ b/src/Language/Avro/Types.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE StandaloneDeriving #-}
-
 -- | Language definition for AVRO (@.avdl@) files,
 --   as defined in <http://avro.apache.org/docs/1.8.2/spec.html>.
 module Language.Avro.Types
@@ -32,24 +30,6 @@ instance Semigroup Protocol where
       (imports p1 <> imports p2)
       (types p1 <> types p2)
       (messages p1 <> messages p2)
-
-deriving instance Ord LogicalTypeInt
-
-deriving instance Ord LogicalTypeLong
-
-deriving instance Ord LogicalTypeBytes
-
-deriving instance Ord Decimal
-
-deriving instance Ord LogicalTypeString
-
-deriving instance Ord LogicalTypeFixed
-
-deriving instance (Ord a) => Ord (Value a)
-
-deriving instance Ord Field
-
-deriving instance Ord Schema
 
 -- | Newtype for the namespace of methods and protocols.
 newtype Namespace

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -3,5 +3,4 @@ packages:
 - .
 extra-deps:
 - HasBigDecimal-0.1.1
-- git: https://github.com/serras/avro.git
-  commit: c684139b773c296079a2941fb30ee43a52b66204
+- avro-0.4.7.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,5 +3,4 @@ packages:
 - .
 extra-deps:
 - HasBigDecimal-0.1.1
-- git: https://github.com/serras/avro.git
-  commit: c684139b773c296079a2941fb30ee43a52b66204
+- avro-0.4.7.0


### PR DESCRIPTION
This release:
- Adds parsing for the new `Decimal` type (and other logical types).
- Solves a bug with `readWithImports`, which now understands relative and absolute paths.