### PR TITLE
Add stack.yaml configurations for Aeson 2.x

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -26,3 +26,7 @@ jobs:
         run: |
           stack build
           stack test
+      - name: Build & Run Tests with Aeson 2.0 & Avro 0.6
+        run: |
+          stack build --stack-yaml stack-aeson2.yaml
+          stack test --stack-yaml stack-aeson2.yaml

--- a/stack-aeson2.yaml
+++ b/stack-aeson2.yaml
@@ -1,0 +1,6 @@
+resolver: nightly-2022-01-20
+packages:
+  - .
+extra-deps:
+- aeson-2.0.3.0
+- avro-0.6.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-18.19
+resolver: lts-18.22
 packages:
   - .


### PR DESCRIPTION
It seems that the package works fine, it only need to either choose `aeson` 1.x + `avro` 0.5.x, or `aeson` 2.x + `avro` 0.6.x. This PR simply adds an extra `stack.yaml` and the corresponding check in the GH workflow.